### PR TITLE
Add root redirect logic

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import useAuthStore from '@/store/authStore';
+
+const HomePage = () => {
+  const router = useRouter();
+  const { token, setToken } = useAuthStore();
+
+  useEffect(() => {
+    const savedToken = token || localStorage.getItem('access_token');
+
+    if (savedToken) {
+      if (!token) setToken(savedToken);
+      router.replace('/dashboard');
+    } else {
+      router.replace('/login');
+    }
+  }, [router, token, setToken]);
+
+  return null;
+};
+
+export default HomePage;


### PR DESCRIPTION
## Summary
- redirect to dashboard if token exists, otherwise go to login

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841981969a88331b1ee4b4848682795