### PR TITLE
Implement company store and fetching hook

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -6,6 +6,9 @@ import CreateCompanyDialog from './_components/createCompanyDialog';
 import axios from 'axios';
 import toast from 'react-hot-toast';
 import useAuthStore from '@/store/authStore';
+import { DataTable } from '@/components/data-table/data-table';
+import { columns } from './_components/companyColumn';
+import useCompanies from '@/hooks/useCompanies';
 
 export interface NewCompanyType {
   name: string;
@@ -24,7 +27,7 @@ export interface NewCompanyType {
 
 const DashboardPage = () => {
   const [open, setOpen] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
 
   // const [newCompany, setNewCompany] = useState<NewCompanyType>({
   //   name: '',
@@ -45,6 +48,7 @@ const DashboardPage = () => {
   // });
 
   const token = useAuthStore((state) => state.token);
+  const { companies, isLoading: companyLoading, mutate } = useCompanies();
 
   // const updateNewCompany = (
   //   e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -88,7 +92,7 @@ const DashboardPage = () => {
   // };
 
   const handleSubmit = async (data: NewCompanyType) => {
-    setIsLoading(true);
+    setIsCreating(true);
     try {
       const res = await axios.post('/api/company', data, {
         headers: {
@@ -98,13 +102,14 @@ const DashboardPage = () => {
       if (res.data.status === 200) {
         toast.success(res.data.message);
         setOpen(false);
+        mutate();
       } else {
         toast.error(res.data.message);
       }
     } catch (error) {
       console.error(error);
     } finally {
-      setIsLoading(false);
+      setIsCreating(false);
     }
   };
 
@@ -115,13 +120,17 @@ const DashboardPage = () => {
         <CreateCompanyDialog
           open={open}
           setOpen={setOpen}
-          isLoading={isLoading}
+          isLoading={isCreating}
           onSubmit={handleSubmit}
         />
       </div>
       <Card>
         <CardContent className='p-6'>
-          <div>這裡是 Data Table 的位置</div>
+          {companyLoading ? (
+            <p>載入中...</p>
+          ) : (
+            <DataTable data={companies} columns={columns(mutate)} page='0' />
+          )}
         </CardContent>
       </Card>
     </div>

--- a/hooks/useCompanies.ts
+++ b/hooks/useCompanies.ts
@@ -1,0 +1,40 @@
+'use client';
+import useSWR from 'swr';
+import axios from 'axios';
+import { useEffect } from 'react';
+import useAuthStore from '@/store/authStore';
+import useCompanyStore from '@/store/companyStore';
+
+const fetcher = (url: string, token: string) =>
+  axios.get(url, { headers: { Authorization: `Bearer ${token}` } }).then((res) => res.data);
+
+const useCompanies = () => {
+  const token = useAuthStore((state) => state.token);
+  const logout = useAuthStore((state) => state.logout);
+  const setCompanies = useCompanyStore((state) => state.setCompanies);
+
+  const { data, error, mutate, isLoading } = useSWR(
+    token ? ['/api/company', token] : null,
+    ([url, t]) => fetcher(url, t),
+  );
+
+  useEffect(() => {
+    if (data) {
+      if (data.status === 200) {
+        setCompanies(data.companies);
+      } else if (data.status === 401 || data.status === 403) {
+        logout('請重新登入');
+      }
+    }
+  }, [data, setCompanies, logout]);
+
+  useEffect(() => {
+    if (error) {
+      logout('請重新登入');
+    }
+  }, [error, logout]);
+
+  return { companies: data?.companies || [], mutate, isLoading };
+};
+
+export default useCompanies;

--- a/store/authStore.ts
+++ b/store/authStore.ts
@@ -5,7 +5,7 @@ interface AuthState {
   user: { email: string } | null;
   setToken: (token: string) => void;
   setUser: (user: { email: string }) => void;
-  logout: () => void;
+  logout: (msg?: string) => void;
 }
 
 const useAuthStore = create<AuthState>((set) => {
@@ -14,9 +14,9 @@ const useAuthStore = create<AuthState>((set) => {
     user: null,
     setToken: (token) => set({ token }),
     setUser: (user) => set({ user }),
-    logout: () => {
+    logout: (msg = '登出成功') => {
       localStorage.removeItem('access_token');
-      localStorage.setItem('logoutMsg', '登出成功');
+      localStorage.setItem('logoutMsg', msg);
       set({ token: null, user: null });
       window.location.href = '/login';
     },

--- a/store/companyStore.ts
+++ b/store/companyStore.ts
@@ -1,0 +1,36 @@
+import { create } from 'zustand';
+
+export interface Fingerprint {
+  value: string;
+  registeredAt: string;
+  status: 'active' | 'revoked';
+}
+
+export interface Company {
+  _id: string;
+  companyId: string;
+  name: string;
+  deployKey: string;
+  fingerprints: Fingerprint[];
+  active: boolean;
+  phone: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface CompanyState {
+  companies: Company[];
+  setCompanies: (companies: Company[]) => void;
+  editCompany: (company: Company) => void;
+}
+
+const useCompanyStore = create<CompanyState>((set) => ({
+  companies: [],
+  setCompanies: (companies) => set({ companies }),
+  editCompany: (company) =>
+    set((state) => ({
+      companies: state.companies.map((c) => (c._id === company._id ? company : c)),
+    })),
+}));
+
+export default useCompanyStore;


### PR DESCRIPTION
## Summary
- manage company list in Zustand store
- allow custom logout messages for auth store
- fetch companies with `useSWR` and store them
- show companies in dashboard using `DataTable`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68423e0636e88331bc3c977a8dc2c201