### PR TITLE
Implement company store and fetching hook

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -6,6 +6,9 @@ import CreateCompanyDialog from './_components/createCompanyDialog';
 import axios from 'axios';
 import toast from 'react-hot-toast';
 import useAuthStore from '@/store/authStore';
+import { DataTable } from '@/components/data-table/data-table';
+import { columns } from './_components/companyColumn';
+import useCompanies from '@/hooks/useCompanies';
 
 export interface NewCompanyType {
   name: string;
@@ -24,7 +27,7 @@ export interface NewCompanyType {
 
 const DashboardPage = () => {
   const [open, setOpen] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
 
   // const [newCompany, setNewCompany] = useState<NewCompanyType>({
   //   name: '',
@@ -45,6 +48,7 @@ const DashboardPage = () => {
   // });
 
   const token = useAuthStore((state) => state.token);
+  const { companies, isLoading: companyLoading, mutate } = useCompanies();
 
   // const updateNewCompany = (
   //   e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -88,7 +92,7 @@ const DashboardPage = () => {
   // };
 
   const handleSubmit = async (data: NewCompanyType) => {
-    setIsLoading(true);
+    setIsCreating(true);
     try {
       const res = await axios.post('/api/company', data, {
         headers: {
@@ -98,13 +102,14 @@ const DashboardPage = () => {
       if (res.data.status === 200) {
         toast.success(res.data.message);
         setOpen(false);
+        mutate();
       } else {
         toast.error(res.data.message);
       }
     } catch (error) {
       console.error(error);
     } finally {
-      setIsLoading(false);
+      setIsCreating(false);
     }
   };
 
@@ -115,13 +120,17 @@ const DashboardPage = () => {
         <CreateCompanyDialog
           open={open}
           setOpen={setOpen}
-          isLoading={isLoading}
+          isLoading={isCreating}
           onSubmit={handleSubmit}
         />
       </div>
       <Card>
         <CardContent className='p-6'>
-          <div>這裡是 Data Table 的位置</div>
+          {companyLoading ? (
+            <p>載入中...</p>
+          ) : (
+            <DataTable data={companies} columns={columns(mutate)} page='0' />
+          )}
         </CardContent>
       </Card>
     </div>

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -6,77 +6,75 @@ import { XIcon } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
-const Dialog = ({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) => {
-  return <DialogPrimitive.Root data-slot='dialog' {...props} />;
-};
+const Dialog = DialogPrimitive.Root;
 
-const DialogTrigger = ({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Trigger>) => {
-  return <DialogPrimitive.Trigger data-slot='dialog-trigger' {...props} />;
-};
+const DialogTrigger = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Trigger>
+>(({ ...props }, ref) => (
+  <DialogPrimitive.Trigger ref={ref} data-slot='dialog-trigger' {...props} />
+));
+DialogTrigger.displayName = DialogPrimitive.Trigger.displayName;
 
-const DialogPortal = ({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Portal>) => {
-  return <DialogPrimitive.Portal data-slot='dialog-portal' {...props} />;
-};
+const DialogPortal = ({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) => (
+  <DialogPrimitive.Portal data-slot='dialog-portal' {...props} />
+);
 
-const DialogClose = ({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Close>) => {
-  return <DialogPrimitive.Close data-slot='dialog-close' {...props} />;
-};
+const DialogClose = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Close>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Close>
+>(({ ...props }, ref) => (
+  <DialogPrimitive.Close ref={ref} data-slot='dialog-close' {...props} />
+));
+DialogClose.displayName = DialogPrimitive.Close.displayName;
 
-const DialogOverlay = ({
-  className,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Overlay>) => {
-  return (
-    <DialogPrimitive.Overlay
-      data-slot='dialog-overlay'
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    data-slot='dialog-overlay'
+    className={cn(
+      'fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+    showCloseButton?: boolean;
+  }
+>(({ className, children, showCloseButton = true, ...props }, ref) => (
+  <DialogPortal data-slot='dialog-portal'>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      data-slot='dialog-content'
       className={cn(
-        'fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+        'bg-background fixed left-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:max-w-lg',
         className,
       )}
       {...props}
-    />
-  );
-};
-
-const DialogContent = ({
-  className,
-  children,
-  showCloseButton = true,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Content> & {
-  showCloseButton?: boolean;
-}) => {
-  return (
-    <DialogPortal data-slot='dialog-portal'>
-      <DialogOverlay />
-      <DialogPrimitive.Content
-        data-slot='dialog-content'
-        className={cn(
-          'bg-background fixed left-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:max-w-lg',
-          className,
-        )}
-        {...props}
-      >
-        {children}
-        {showCloseButton && (
-          <DialogPrimitive.Close
-            data-slot='dialog-close'
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground rounded-xs focus:outline-hidden [&_svg:not([class*='size-'])]:size-4 absolute right-4 top-4 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0"
-          >
-            <XIcon />
-            <span className='sr-only'>Close</span>
-          </DialogPrimitive.Close>
-        )}
-      </DialogPrimitive.Content>
-    </DialogPortal>
-  );
-};
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close
+          data-slot='dialog-close'
+          className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground rounded-xs focus:outline-hidden [&_svg:not([class*='size-'])]:size-4 absolute right-4 top-4 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0"
+        >
+          <XIcon />
+          <span className='sr-only'>Close</span>
+        </DialogPrimitive.Close>
+      )}
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({ className, ...props }: React.ComponentProps<'div'>) => {
   return (

--- a/hooks/useCompanies.ts
+++ b/hooks/useCompanies.ts
@@ -1,0 +1,40 @@
+'use client';
+import useSWR from 'swr';
+import axios from 'axios';
+import { useEffect } from 'react';
+import useAuthStore from '@/store/authStore';
+import useCompanyStore from '@/store/companyStore';
+
+const fetcher = (url: string, token: string) =>
+  axios.get(url, { headers: { Authorization: `Bearer ${token}` } }).then((res) => res.data);
+
+const useCompanies = () => {
+  const token = useAuthStore((state) => state.token);
+  const logout = useAuthStore((state) => state.logout);
+  const setCompanies = useCompanyStore((state) => state.setCompanies);
+
+  const { data, error, mutate, isLoading } = useSWR(
+    token ? ['/api/company', token] : null,
+    ([url, t]) => fetcher(url, t),
+  );
+
+  useEffect(() => {
+    if (data) {
+      if (data.status === 200) {
+        setCompanies(data.companies);
+      } else if (data.status === 401 || data.status === 403) {
+        logout('請重新登入');
+      }
+    }
+  }, [data, setCompanies, logout]);
+
+  useEffect(() => {
+    if (error) {
+      logout('請重新登入');
+    }
+  }, [error, logout]);
+
+  return { companies: data?.companies || [], mutate, isLoading };
+};
+
+export default useCompanies;

--- a/store/authStore.ts
+++ b/store/authStore.ts
@@ -5,7 +5,7 @@ interface AuthState {
   user: { email: string } | null;
   setToken: (token: string) => void;
   setUser: (user: { email: string }) => void;
-  logout: () => void;
+  logout: (msg?: string) => void;
 }
 
 const useAuthStore = create<AuthState>((set) => {
@@ -14,9 +14,9 @@ const useAuthStore = create<AuthState>((set) => {
     user: null,
     setToken: (token) => set({ token }),
     setUser: (user) => set({ user }),
-    logout: () => {
+    logout: (msg = '登出成功') => {
       localStorage.removeItem('access_token');
-      localStorage.setItem('logoutMsg', '登出成功');
+      localStorage.setItem('logoutMsg', msg);
       set({ token: null, user: null });
       window.location.href = '/login';
     },

--- a/store/companyStore.ts
+++ b/store/companyStore.ts
@@ -1,0 +1,36 @@
+import { create } from 'zustand';
+
+export interface Fingerprint {
+  value: string;
+  registeredAt: string;
+  status: 'active' | 'revoked';
+}
+
+export interface Company {
+  _id: string;
+  companyId: string;
+  name: string;
+  deployKey: string;
+  fingerprints: Fingerprint[];
+  active: boolean;
+  phone: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface CompanyState {
+  companies: Company[];
+  setCompanies: (companies: Company[]) => void;
+  editCompany: (company: Company) => void;
+}
+
+const useCompanyStore = create<CompanyState>((set) => ({
+  companies: [],
+  setCompanies: (companies) => set({ companies }),
+  editCompany: (company) =>
+    set((state) => ({
+      companies: state.companies.map((c) => (c._id === company._id ? company : c)),
+    })),
+}));
+
+export default useCompanyStore;


### PR DESCRIPTION
## Summary
- manage company list in Zustand store
- allow custom logout messages for auth store
- fetch companies with `useSWR` and store them
- show companies in dashboard using `DataTable`
- forward refs in `Dialog` components

## Testing
- `npm run lint` *(fails with multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68423e0636e88331bc3c977a8dc2c201