### PR TITLE
Implement company detail page & update company API

### DIFF
--- a/app/api/company/[id]/route.ts
+++ b/app/api/company/[id]/route.ts
@@ -1,0 +1,134 @@
+import { NextResponse } from 'next/server';
+import connect from '@/lib/mongodb';
+import Company, { CompanyType, FingerprintType } from '@/models/Company';
+import { authenticateToken } from '@/lib/authMiddleware';
+import { z } from 'zod';
+
+const fingerprintSchema = z.object({
+  value: z.string().min(1),
+  licenseType: z.enum(['subscription', 'lifetime']).optional(),
+  expiryDate: z.string().optional().nullable(),
+  status: z.enum(['active', 'revoked']).optional(),
+});
+
+const updateSchema = z
+  .object({
+    name: z.string().min(1).optional(),
+    companyId: z.string().min(1).optional(),
+    email: z.string().email().optional(),
+    phone: z.string().min(1).optional(),
+    address: z.string().min(1).optional(),
+    deployKey: z.string().min(1).optional(),
+    fingerprints: z.array(fingerprintSchema).optional(),
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: '缺少更新資料',
+  });
+
+export async function GET(
+  req: Request,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  try {
+    await connect();
+
+    const authHeader = req.headers.get('Authorization');
+    const token = authHeader && authHeader.split(' ')[1];
+    if (!token) return NextResponse.json({ status: 401, message: '請先登入' });
+
+    const user = await authenticateToken(token);
+    if (!user) return NextResponse.json({ status: 403, message: 'Token已過期' });
+
+    const company = await Company.findById(params.id);
+    if (!company) {
+      return NextResponse.json({ status: 404, message: '公司不存在' });
+    }
+
+    return NextResponse.json({ status: 200, company });
+  } catch (error) {
+    console.error('[GET COMPANY]', error);
+    return NextResponse.json(
+      { status: 500, message: '伺服器發生錯誤，請稍後再試' },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PUT(
+  req: Request,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  try {
+    await connect();
+
+    const authHeader = req.headers.get('Authorization');
+    const token = authHeader && authHeader.split(' ')[1];
+    if (!token) return NextResponse.json({ status: 401, message: '請先登入' });
+
+    const user = await authenticateToken(token);
+    if (!user) return NextResponse.json({ status: 403, message: 'Token已過期' });
+
+    const body = await req.json();
+    const parseResult = updateSchema.safeParse(body);
+    if (!parseResult.success) {
+      return NextResponse.json({ status: 400, message: parseResult.error.message });
+    }
+
+    const { name, companyId, email, phone, address, deployKey, fingerprints } =
+      parseResult.data;
+
+    const updateData: Partial<CompanyType> = {};
+    if (name) updateData.name = name;
+    if (companyId) updateData.companyId = companyId;
+    if (email) updateData.email = email;
+    if (phone) updateData.phone = phone;
+    if (address) updateData.address = address;
+    if (deployKey) updateData.deployKey = deployKey;
+
+    if (Array.isArray(fingerprints)) {
+      for (const fp of fingerprints) {
+        if (!fp.value) {
+          return NextResponse.json({
+            status: 400,
+            message: '每個設備都需包含「設備ID」',
+          });
+        }
+        if (fp.licenseType === 'subscription' && !fp.expiryDate) {
+          return NextResponse.json({
+            status: 400,
+            message: '訂閱制需設定「到期日期」',
+          });
+        }
+      }
+      updateData.fingerprints = fingerprints.map((fp: FingerprintType) => ({
+        value: fp.value,
+        licenseType: fp.licenseType || 'lifetime',
+        expiryDate: fp.expiryDate || null,
+        status: fp.status || 'active',
+      }));
+    }
+
+    updateData.updatedAt = new Date();
+    updateData.updatedBy = user._id;
+
+    const updatedCompany = await Company.findByIdAndUpdate(params.id, updateData, {
+      new: true,
+    });
+
+    if (!updatedCompany) {
+      return NextResponse.json({ status: 404, message: '公司不存在' });
+    }
+
+    return NextResponse.json({
+      status: 200,
+      message: '公司資料已更新',
+      company: updatedCompany,
+    });
+  } catch (error) {
+    console.error('[UPDATE COMPANY]', error);
+    return NextResponse.json(
+      { status: 500, message: '伺服器發生錯誤，請稍後再試' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/company/route.ts
+++ b/app/api/company/route.ts
@@ -1,6 +1,17 @@
 import { NextResponse } from 'next/server';
 import connect from '@/lib/mongodb';
-import Company from '@/models/Company';
+import Company, { FingerprintType } from '@/models/Company';
+
+interface CreateCompanyPayload {
+  name: string;
+  companyId: string;
+  email: string;
+  phone: string;
+  address: string;
+  deployKey: string;
+  fingerprints: FingerprintType[];
+}
+
 import { authenticateToken } from '@/lib/authMiddleware';
 
 export async function POST(req: Request): Promise<NextResponse> {
@@ -14,8 +25,15 @@ export async function POST(req: Request): Promise<NextResponse> {
     const user = await authenticateToken(token);
     if (!user) return NextResponse.json({ status: 403, message: 'Token已過期' });
 
-    const { name, companyId, email, phone, address, deployKey, fingerprints } =
-      await req.json();
+    const {
+      name,
+      companyId,
+      email,
+      phone,
+      address,
+      deployKey,
+      fingerprints,
+    } = (await req.json()) as CreateCompanyPayload;
 
     // 驗證必填欄位
     if (
@@ -108,3 +126,4 @@ export async function GET(req: Request): Promise<NextResponse> {
     );
   }
 }
+

--- a/app/company/[id]/page.tsx
+++ b/app/company/[id]/page.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import axios from 'axios';
+import toast from 'react-hot-toast';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import useAuthStore from '@/store/authStore';
+import useCompanyStore from '@/store/companyStore';
+import { FingerprintType } from '@/models/Company';
+
+const formSchema = z.object({
+  name: z.string().min(1, '公司名稱必填'),
+  companyId: z.string().min(1, '公司統編必填'),
+  email: z.string().email('Email格式錯誤'),
+  phone: z.string().min(1, '電話必填'),
+  address: z.string().min(1, '地址必填'),
+  deployKey: z.string().min(1, '部署金鑰必填'),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+const CompanyPage = () => {
+  const params = useParams<{ id: string }>();
+  const editCompany = useCompanyStore((state) => state.editCompany);
+  const token =
+    useAuthStore((state) => state.token) ||
+    (typeof window !== 'undefined' ? localStorage.getItem('access_token') : null);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+  });
+
+  const [editing, setEditing] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [fingerprints, setFingerprints] = useState<FingerprintType[]>([]);
+
+  useEffect(() => {
+    const fetchCompany = async () => {
+      if (!token) return;
+      try {
+        const res = await axios.get(`/api/company/${params.id}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (res.data.status === 200) {
+          const c = res.data.company;
+          setFingerprints(c.fingerprints || []);
+          reset({
+            name: c.name,
+            companyId: c.companyId,
+            email: c.email,
+            phone: c.phone,
+            address: c.address,
+            deployKey: c.deployKey,
+          });
+        } else {
+          toast.error(res.data.message);
+        }
+      } catch (err) {
+        toast.error('資料載入失敗');
+      }
+    };
+    fetchCompany();
+  }, [params.id, token, reset]);
+
+  const onSubmit = async (data: FormValues) => {
+    if (!token) {
+      toast.error('尚未登入');
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await axios.put(
+        `/api/company/${params.id}`,
+        data,
+        { headers: { Authorization: `Bearer ${token}` } },
+      );
+      if (res.data.status === 200) {
+        toast.success(res.data.message);
+        editCompany(res.data.company);
+        setEditing(false);
+      } else {
+        toast.error(res.data.message);
+      }
+    } catch (err) {
+      toast.error('更新失敗');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className='space-y-6'>
+      <div className='flex items-center justify-between'>
+        <h2 className='text-2xl font-semibold'>公司資訊</h2>
+        {!editing ? (
+          <Button onClick={() => setEditing(true)}>編輯</Button>
+        ) : (
+          <div className='flex gap-2'>
+            <Button onClick={handleSubmit(onSubmit)} disabled={loading}>
+              {loading ? '儲存中...' : '儲存'}
+            </Button>
+            <Button
+              variant='outline'
+              onClick={() => {
+                setEditing(false);
+              }}
+            >
+              取消
+            </Button>
+          </div>
+        )}
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>基本資料</CardTitle>
+        </CardHeader>
+        <CardContent className='grid grid-cols-1 gap-4 md:grid-cols-2'>
+          <InputBlock id='name' label='公司名稱' register={register} error={errors.name} disabled={!editing} />
+          <InputBlock id='companyId' label='公司統編' register={register} error={errors.companyId} disabled={!editing} />
+          <InputBlock id='email' label='公司 Email' register={register} error={errors.email} disabled={!editing} />
+          <InputBlock id='phone' label='電話' register={register} error={errors.phone} disabled={!editing} />
+          <InputBlock id='deployKey' label='部署金鑰' register={register} error={errors.deployKey} disabled={!editing} />
+          <div className='flex flex-col gap-1 md:col-span-2'>
+            <Label htmlFor='address'>
+              公司地址 <span className='text-red-500'>*</span>
+            </Label>
+            <Textarea id='address' {...register('address')} className='resize-none' disabled={!editing} />
+            {errors.address && <p className='text-sm text-red-500'>{errors.address.message}</p>}
+          </div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>授權設備</CardTitle>
+        </CardHeader>
+        <CardContent className='space-y-2'>
+          {fingerprints.length === 0 ? (
+            <p className='text-sm text-muted-foreground'>尚無授權設備</p>
+          ) : (
+            fingerprints.map((fp, idx) => (
+              <div key={idx} className='rounded-md border p-3 text-sm shadow-sm'>
+                <p className='break-all font-mono text-xs'>
+                  <strong>設備ID：</strong> {fp.value}
+                </p>
+                <p className='text-xs'>授權：{fp.licenseType}</p>
+                {fp.expiryDate && <p className='text-xs'>到期日：{fp.expiryDate}</p>}
+                <p className='text-muted-foreground text-xs'>
+                  註冊時間：{new Date(fp.registeredAt).toLocaleDateString()}
+                </p>
+              </div>
+            ))
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+interface InputBlockProps {
+  id: keyof FormValues;
+  label: string;
+  register: ReturnType<typeof useForm<FormValues>>['register'];
+  error?: { message?: string };
+  disabled: boolean;
+}
+
+const InputBlock = ({ id, label, register, error, disabled }: InputBlockProps) => (
+  <div className='flex flex-col gap-1'>
+    <Label htmlFor={id}>
+      {label} <span className='text-red-500'>*</span>
+    </Label>
+    <Input id={id} {...register(id)} disabled={disabled} />
+    {error?.message && <p className='text-sm text-red-500'>{error.message}</p>}
+  </div>
+);
+
+export default CompanyPage;

--- a/app/dashboard/_components/viewFingerprintDialog.tsx
+++ b/app/dashboard/_components/viewFingerprintDialog.tsx
@@ -1,5 +1,10 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useForm, useFieldArray, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
 import { Button } from '@/components/ui/button';
-import toast from 'react-hot-toast';
 import {
   Dialog,
   DialogContent,
@@ -7,34 +12,121 @@ import {
   DialogHeader,
   DialogTitle,
   DialogDescription,
+  DialogFooter,
 } from '@/components/ui/dialog';
-import { Monitor } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import DatePicker from '@/components/datePicker/datePicker';
+import { Monitor, LoaderCircle } from 'lucide-react';
 import axios from 'axios';
+import toast from 'react-hot-toast';
+import useAuthStore from '@/store/authStore';
+import useCompanyStore from '@/store/companyStore';
 
 export type Fingerprint = {
   value: string;
   registeredAt: string;
+  licenseType: 'subscription' | 'lifetime';
+  expiryDate?: string | null;
   status: 'active' | 'revoked';
 };
 
-const ViewFingerprintDialog = ({
-  companyId,
-  fingerprints,
-  mutate,
-}: {
+const fingerprintSchema = z.object({
+  value: z.string().min(1, '設備ID 必填'),
+  licenseType: z.enum(['subscription', 'lifetime']),
+  expiryDate: z.date().optional(),
+  status: z.enum(['active', 'revoked']),
+});
+
+const formSchema = z.object({
+  fingerprints: z.array(fingerprintSchema).min(1, '至少一筆設備授權'),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+interface Props {
   companyId: string;
   fingerprints: Fingerprint[];
   mutate?: () => void;
-}) => {
+}
+
+const ViewFingerprintDialog = ({ companyId, fingerprints, mutate }: Props) => {
+  const token =
+    useAuthStore((state) => state.token) ||
+    (typeof window !== 'undefined' ? localStorage.getItem('access_token') : null);
+  const editCompany = useCompanyStore((state) => state.editCompany);
+
+  const defaultValues: FormValues = {
+    fingerprints: fingerprints.map((fp) => ({
+      value: fp.value,
+      licenseType: fp.licenseType,
+      expiryDate: fp.expiryDate ? new Date(fp.expiryDate) : new Date(),
+      status: fp.status,
+    })),
+  };
+
+  const {
+    register,
+    control,
+    handleSubmit,
+    watch,
+  } = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues,
+  });
+
+  const { fields, append } = useFieldArray({ control, name: 'fingerprints' });
+
+  const [isSaving, setIsSaving] = useState(false);
+  const [dateOpenMap, setDateOpenMap] = useState<Record<string, boolean>>({});
+
+  const watchFingerprints = watch('fingerprints');
+
+  const onSubmit = async (data: FormValues) => {
+    if (!token) {
+      toast.error('尚未登入');
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const res = await axios.put(
+        `/api/company/${companyId}`,
+        {
+          fingerprints: data.fingerprints.map((fp) => ({
+            value: fp.value,
+            licenseType: fp.licenseType,
+            expiryDate: fp.licenseType === 'subscription' ? fp.expiryDate : null,
+            status: fp.status,
+          })),
+        },
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+
+      if (res.data.status === 200) {
+        toast.success(res.data.message);
+        editCompany(res.data.company);
+        if (mutate) mutate();
+      } else {
+        toast.error(res.data.message);
+      }
+    } catch (err) {
+      toast.error('操作失敗，請稍後再試');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
   const toggleStatus = async (value: string, currentStatus: 'active' | 'revoked') => {
     try {
-      const res = await axios.put('/api/company/fingerprint-status', {
-        companyId,
-        fingerprint: value,
-        newStatus: currentStatus === 'active' ? 'revoked' : 'active',
+      const res = await axios.put(`/api/company/${companyId}`, {
+        fingerprints: [{ value, status: currentStatus === 'active' ? 'revoked' : 'active' }],
       });
       if (res.data.status === 200) {
         toast.success(res.data.message);
+        editCompany(res.data.company);
         if (mutate) mutate();
       } else {
         toast.error(res.data.message);
@@ -56,39 +148,96 @@ const ViewFingerprintDialog = ({
           <DialogTitle>授權設備列表</DialogTitle>
           <DialogDescription>查看與管理此公司已註冊的設備</DialogDescription>
         </DialogHeader>
-        <div className='space-y-4'>
-          {fingerprints.length === 0 ? (
-            <p className='text-muted-foreground text-sm'>尚無授權設備</p>
-          ) : (
-            fingerprints.map((fp, idx) => (
-              <div key={idx} className='rounded-md border p-3 text-sm shadow-sm'>
-                <p className='break-all font-mono text-xs'>
-                  <strong>設備ID：</strong> {fp.value}
-                </p>
-                <p className='text-muted-foreground text-xs'>
-                  註冊時間：{new Date(fp.registeredAt).toLocaleDateString()}
-                </p>
+        <form onSubmit={handleSubmit(onSubmit)} className='space-y-4'>
+          {fields.map((field, index) => {
+            const currentLicenseType = watchFingerprints?.[index]?.licenseType;
+            const fpStatus = watchFingerprints?.[index]?.status;
+            return (
+              <div key={field.id} className='rounded-md border p-3 text-sm shadow-sm space-y-2'>
+                <Input {...register(`fingerprints.${index}.value`)} placeholder='設備ID' />
+                <Controller
+                  control={control}
+                  name={`fingerprints.${index}.licenseType`}
+                  render={({ field }) => (
+                    <RadioGroup
+                      value={field.value}
+                      onValueChange={field.onChange}
+                      className='flex gap-4'
+                    >
+                      <div className='flex items-center space-x-2'>
+                        <RadioGroupItem value='subscription' id={`sub-${field.id}`} />
+                        <label htmlFor={`sub-${field.id}`}>訂閱制</label>
+                      </div>
+                      <div className='flex items-center space-x-2'>
+                        <RadioGroupItem value='lifetime' id={`life-${field.id}`} />
+                        <label htmlFor={`life-${field.id}`}>買斷制</label>
+                      </div>
+                    </RadioGroup>
+                  )}
+                />
+                {currentLicenseType === 'subscription' && (
+                  <Controller
+                    control={control}
+                    name={`fingerprints.${index}.expiryDate`}
+                    render={({ field }) => (
+                      <DatePicker
+                        defaultDate={field.value}
+                        updateDate={field.onChange}
+                        openDatePicker={dateOpenMap[field.id] || false}
+                        setOpenDatePicker={(open) =>
+                          setDateOpenMap((prev) => ({ ...prev, [field.id]: open }))
+                        }
+                      />
+                    )}
+                  />
+                )}
                 <div className='flex items-center justify-between pt-1'>
                   <p
                     className={`text-xs font-medium ${
-                      fp.status === 'active' ? 'text-green-600' : 'text-red-500'
+                      fpStatus === 'active' ? 'text-green-600' : 'text-red-500'
                     }`}
                   >
-                    狀態：{fp.status === 'active' ? '啟用中' : '已撤銷'}
+                    狀態：{fpStatus === 'active' ? '啟用中' : '已撤銷'}
                   </p>
                   <Button
+                    type='button'
                     size='sm'
                     variant='outline'
                     className='h-6 text-xs'
-                    onClick={() => toggleStatus(fp.value, fp.status)}
+                    onClick={() => toggleStatus(field.value, fpStatus)}
                   >
-                    {fp.status === 'active' ? '撤銷' : '啟用'}
+                    {fpStatus === 'active' ? '撤銷' : '啟用'}
                   </Button>
                 </div>
               </div>
-            ))
-          )}
-        </div>
+            );
+          })}
+          <Button
+            type='button'
+            variant='outline'
+            onClick={() =>
+              append({
+                value: '',
+                licenseType: 'lifetime',
+                expiryDate: new Date(),
+                status: 'active',
+              })
+            }
+          >
+            新增設備
+          </Button>
+          <DialogFooter>
+            <Button type='submit' disabled={isSaving}>
+              {isSaving ? (
+                <span className='flex items-center gap-2'>
+                  <LoaderCircle className='h-4 w-4 animate-spin' /> 儲存中...
+                </span>
+              ) : (
+                '儲存'
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## Summary
- create dynamic company detail page under `app/company/[id]`
- extend company API with single fetch capability and PUT update handler
- enable editing of fingerprint license in `ViewFingerprintDialog`
- strictly type API request payloads to avoid `any`
- move update endpoint to `api/company/[id]` and validate request payload

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684296d06f58833185d061b0b4217265