### PR TITLE
Fix localStorage access in client hook

### DIFF
--- a/hooks/useCompanies.ts
+++ b/hooks/useCompanies.ts
@@ -13,7 +13,8 @@ const fetcher = (url: string, token: string) =>
 
 const useCompanies = () => {
   const token =
-    useAuthStore((state) => state.token) || localStorage.getItem('access_token');
+    useAuthStore((state) => state.token) ||
+    (typeof window !== 'undefined' ? localStorage.getItem('access_token') : null);
   const logout = useAuthStore((state) => state.logout);
   const setCompanies = useCompanyStore((state) => state.setCompanies);
   const companies = useCompanyStore((state) => state.companies);


### PR DESCRIPTION
## Summary
- fix localStorage usage in `useCompanies` by guarding against server-side usage

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6842b8d964dc833189ed224d937b5fe9